### PR TITLE
Support for nested array defaults

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -165,7 +165,21 @@
     } else if (schema.type === 'array') {
 
       if (!schema.items) { return []; }
-      return [defaults(schema.items, definitions)];
+      
+      // minimum item count
+      var ct = schema.minItems || 0;
+
+      // tuple-typed arrays
+      if (schema.items.constructor === Array) {
+        return schema.items.slice(0, ct).map(function (item) {
+          return defaults(item, definitions);
+        });
+      }
+
+      // object-typed arrays
+      return Array.apply(0, Array(ct)).map(function (item) {
+        return defaults(schema.items, definitions);
+      });
 
     }
 


### PR DESCRIPTION
Array types without a defaults property will recursively build defaults abiding by minItems (if present). Supports tuple-typing (http://spacetelescope.github.io/understanding-json-schema/reference/array.html#tuple-validation) and object-typing.
